### PR TITLE
Fix static initialization issues in debug configs

### DIFF
--- a/src/nexus/check.cc
+++ b/src/nexus/check.cc
@@ -3,10 +3,11 @@
 // TODO: replace with proper log
 #include <iostream>
 
-void nx::detail::report_failed_check(nx::detail::check_result const& r, const char* check, const char* file, int line, bool terminate)
+void nx::detail::report_failed_check(nx::detail::check_result const& r, const char* check, const char* file, int line, char const* function, bool terminate)
 {
     std::cerr << "CHECK( " << check << " ) failed." << std::endl;
     std::cerr << "  in " << file << ":" << line << std::endl;
+    std::cerr << "  function " << function << std::endl;
     if (r.lhs && !r.rhs)
         std::cout << "  value: " << r.lhs << std::endl;
     else if (r.lhs && r.rhs)

--- a/src/nexus/check.hh
+++ b/src/nexus/check.hh
@@ -19,12 +19,12 @@
 
 // ================= Implementation =================
 
-#define NX_IMPL_CHECK(terminate, ...)                                                          \
-    do                                                                                         \
-    {                                                                                          \
-        ::nx::detail::check_result r = ::nx::detail::start_check{} < __VA_ARGS__;              \
-        if (!r.is_true)                                                                        \
-            ::nx::detail::report_failed_check(r, #__VA_ARGS__, __FILE__, __LINE__, terminate); \
+#define NX_IMPL_CHECK(terminate, ...)                                                                          \
+    do                                                                                                         \
+    {                                                                                                          \
+        ::nx::detail::check_result r = ::nx::detail::start_check{} < __VA_ARGS__;                              \
+        if (!r.is_true)                                                                                        \
+            ::nx::detail::report_failed_check(r, #__VA_ARGS__, __FILE__, __LINE__, CC_PRETTY_FUNC, terminate); \
     } while (0)
 
 #define NX_IMPL_FORBID_COMPLEX_CHAIN                                                                                                   \
@@ -115,5 +115,5 @@ struct start_check
     }
 };
 
-void report_failed_check(check_result const& r, char const* check, char const* file, int line, bool terminate);
+void report_failed_check(check_result const& r, char const* check, char const* file, int line, char const* function, bool terminate);
 }

--- a/src/nexus/test.cc
+++ b/src/nexus/test.cc
@@ -7,9 +7,11 @@
 
 using namespace nx;
 
-static cc::vector<cc::unique_ptr<Test>> sAllTests;
-
-cc::vector<cc::unique_ptr<Test>> const& nx::detail::get_all_tests() { return sAllTests; }
+cc::vector<cc::unique_ptr<Test>>& nx::detail::get_all_tests()
+{
+    static cc::vector<cc::unique_ptr<Test>> all_tests;
+    return all_tests;
+}
 
 void nx::detail::configure(Test* t, before const& v) { t->addBeforePattern(v.pattern); }
 
@@ -21,6 +23,6 @@ Test* detail::register_test(const char* name, const char* file, int line, test_f
 {
     auto t = cc::make_unique<Test>(name, file, line, fun);
     auto t_ptr = t.get();
-    sAllTests.push_back(std::move(t));
+    get_all_tests().push_back(std::move(t));
     return t_ptr;
 }

--- a/src/nexus/tests/Test.hh
+++ b/src/nexus/tests/Test.hh
@@ -50,6 +50,6 @@ private:
 
 namespace detail
 {
-cc::vector<cc::unique_ptr<Test>> const& get_all_tests();
+cc::vector<cc::unique_ptr<Test>>& get_all_tests();
 }
 }


### PR DESCRIPTION
In debug configurations, the static `sAllTests` variable was sometimes memset to zero between test registration and `Nexus::run`, leading to no tests being detected.

![registration in debug](https://user-images.githubusercontent.com/17261478/67900981-e98b4d00-fb65-11e9-808a-58d8dd233dff.PNG)

Resolved by using a function local static variable in `get_all_tests` instead.