### PR TITLE
pt/develop plus fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ endif()
 # =========================================
 # global options
 
-option(NEXUS_FORCE_MACRO_PREFIX "if true, only NX_ macro versions are available" OFF)
+option(NX_FORCE_MACRO_PREFIX "if true, only NX_ macro versions are available" OFF)
 
 # =========================================
 # define library
@@ -45,6 +45,7 @@ endif()
 # =========================================
 # set up compile flags
 
-if (NEXUS_FORCE_MACRO_PREFIX)
+# the second option is for backwards compatibility with the previous name
+if (NX_FORCE_MACRO_PREFIX OR NEXUS_FORCE_MACRO_PREFIX)
     target_compile_definitions(nexus PUBLIC NX_FORCE_MACRO_PREFIX)
 endif()

--- a/src/nexus/Nexus.cc
+++ b/src/nexus/Nexus.cc
@@ -181,7 +181,7 @@ int nx::Nexus::run()
         // execute and measure
         auto const start_thread = std::this_thread::get_id();
         auto const start = std::chrono::high_resolution_clock::now();
-        if (t->isDebug())
+        if (t->isDebug() || t->shouldReproduce())
             t->function()();
         else
         {

--- a/src/nexus/Nexus.cc
+++ b/src/nexus/Nexus.cc
@@ -153,24 +153,25 @@ int nx::Nexus::run()
     LOG("run with '--help' for options");
     LOG("detected %s %s", tests.size(), tests.size() == 1 ? "test" : "tests");
     LOG("running %s %s%s", tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests",
-         disabled_tests == 0 ? "" : cc::format(" (%s disabled)", disabled_tests));
+        disabled_tests == 0 ? "" : cc::format(" (%s disabled)", disabled_tests));
     LOG("TEST(..., seed(%s))", seed);
     LOG("==============================================================================");
 
     // execute tests
     // TODO: timings and statistics and so on
     auto total_time_ms = 0.0;
-    auto fails = 0;
-    auto assertions = 0;
-    auto failed_assertions = 0;
-    for (auto t : tests_to_run)
+    auto num_failed_tests = 0;
+    auto total_num_checks = 0;
+    auto total_num_failed_checks = 0;
+
+    for (auto* t : tests_to_run)
     {
         // prepare
-        detail::number_of_assertions() = 0;
-        detail::number_of_failed_assertions() = 0;
         curr_test() = t;
         detail::is_silenced() = t->mShouldFail;
         detail::always_terminate() = false;
+
+        t->mFunctionBefore();
 
         // execute and measure
         auto const start = std::chrono::high_resolution_clock::now();
@@ -189,26 +190,36 @@ int nx::Nexus::run()
         }
         auto const end = std::chrono::high_resolution_clock::now();
 
+        t->mFunctionAfter(t->mCounters);
+
         // report
         curr_test() = nullptr;
-        t->mAssertions = detail::number_of_assertions();
-        t->mFailedAssertions = detail::number_of_failed_assertions();
+
+        auto const num_checks = t->mCounters->num_checks;
+        auto const num_failed_checks = t->mCounters->num_failed_checks;
+
+        total_num_checks += num_checks;
+
+        t->setDidFail(num_failed_checks > 0);
+
         if (t->mShouldFail)
         {
-            if (!t->hasFailed())
+            if (!t->didFail())
             {
-                fails++;
+                num_failed_tests++;
                 LOG_WARN("Test [%s] should have failed but didn't.\n  in %s:%s", t->name(), t->file(), t->line());
             }
         }
         else
         {
-            if (t->hasFailed())
-                fails++;
-            failed_assertions += t->mFailedAssertions;
+            if (t->didFail())
+                num_failed_tests++;
+
+            total_num_failed_checks += num_failed_checks;
         }
-        assertions += t->mAssertions;
-        if (t->mAssertions == 0)
+
+
+        if (num_checks == 0)
             empty_tests.push_back(t);
 
         // reset
@@ -220,23 +231,24 @@ int nx::Nexus::run()
         auto const test_time_ms = std::chrono::duration<double>(end - start).count() * 1000;
         total_time_ms += test_time_ms;
 
-        LOG("  %<60s ... %6d checks in %.4f ms", t->name(), t->mAssertions, test_time_ms);
+        LOG("  %<60s ... %6d checks in %.4f ms", t->name(), num_checks, test_time_ms);
     }
 
     LOG("==============================================================================");
     LOG("passed %d of %d %s in %.4f ms%s", //
-         tests_to_run.size() - fails, tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests", total_time_ms,
-         fails == 0 ? "" : cc::format(" (%d failed)", fails));
-    LOG("checked %d assertions%s", assertions, failed_assertions == 0 ? "" : cc::format(" (%d failed)", failed_assertions));
+        tests_to_run.size() - num_failed_tests, tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests", total_time_ms,
+        num_failed_tests == 0 ? "" : cc::format(" (%d failed)", num_failed_tests));
+    LOG("checked %d assertions%s", total_num_checks, total_num_failed_checks == 0 ? "" : cc::format(" (%d failed)", total_num_failed_checks));
+
     if (tests.empty())
     {
         LOG_WARN("no tests found/selected");
         return EXIT_SUCCESS;
     }
-    else if (fails > 0)
+    else if (num_failed_tests > 0)
     {
         for (auto const& t : tests)
-            if (t->hasFailed() != t->shouldFail())
+            if (t->didFail() != t->shouldFail())
             {
                 cc::string repr;
                 if (t->shouldReproduce())
@@ -255,8 +267,9 @@ int nx::Nexus::run()
                 LOG_WARN("test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
                 LOG_WARN("  %s:%s", t->file(), t->line());
             }
-        LOG_WARN("%d %s failed", failed_assertions, failed_assertions == 1 ? "ASSERTION" : "ASSERTIONS");
-        LOG_WARN("%d %s failed", fails, fails == 1 ? "TEST" : "TESTS");
+
+        LOG_WARN("%d %s failed", total_num_failed_checks, total_num_failed_checks == 1 ? "ASSERTION" : "ASSERTIONS");
+        LOG_WARN("%d %s failed", num_failed_tests, num_failed_tests == 1 ? "TEST" : "TESTS");
         return EXIT_FAILURE;
     }
     else

--- a/src/nexus/Nexus.cc
+++ b/src/nexus/Nexus.cc
@@ -70,15 +70,15 @@ int nx::Nexus::run()
 
     if (mPrintHelp)
     {
-        LOGD(Nexus, Info, "version %s", version);
-        LOGD(Nexus, Info, "");
-        LOGD(Nexus, Info, "usage:");
-        LOGD(Nexus, Info, R"(  --help        shows this help)");
-        LOGD(Nexus, Info, R"(  "test name"   runs all tests named "test name" (quotation marks optional if no space in name))");
-        LOGD(Nexus, Info, "");
-        LOGD(Nexus, Info, "stats:");
-        LOGD(Nexus, Info, " - found %s tests", detail::get_all_tests().size());
-        LOGD(Nexus, Info, " - found %s apps", detail::get_all_apps().size());
+        LOG("version %s", version);
+        LOG("");
+        LOG("usage:");
+        LOG(R"(  --help        shows this help)");
+        LOG(R"(  "test name"   runs all tests named "test name" (quotation marks optional if no space in name))");
+        LOG("");
+        LOG("stats:");
+        LOG(" - found %s tests", detail::get_all_tests().size());
+        LOG(" - found %s apps", detail::get_all_apps().size());
 
         return EXIT_SUCCESS;
     }
@@ -149,13 +149,13 @@ int nx::Nexus::run()
         tests_to_run.push_back(t.get());
     }
 
-    LOGD(Nexus, Info, "version %s", version);
-    LOGD(Nexus, Info, "run with '--help' for options");
-    LOGD(Nexus, Info, "detected %s %s", tests.size(), tests.size() == 1 ? "test" : "tests");
-    LOGD(Nexus, Info, "running %s %s%s", tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests",
+    LOG("version %s", version);
+    LOG("run with '--help' for options");
+    LOG("detected %s %s", tests.size(), tests.size() == 1 ? "test" : "tests");
+    LOG("running %s %s%s", tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests",
          disabled_tests == 0 ? "" : cc::format(" (%s disabled)", disabled_tests));
-    LOGD(Nexus, Info, "TEST(..., seed(%s))", seed);
-    LOGD(Nexus, Info, "==============================================================================");
+    LOG("TEST(..., seed(%s))", seed);
+    LOG("==============================================================================");
 
     // execute tests
     // TODO: timings and statistics and so on
@@ -198,7 +198,7 @@ int nx::Nexus::run()
             if (!t->hasFailed())
             {
                 fails++;
-                LOGD(Nexus, Warning, "Test [%s] should have failed but didn't.\n  in %s:%s", t->name(), t->file(), t->line());
+                LOG_WARN("Test [%s] should have failed but didn't.\n  in %s:%s", t->name(), t->file(), t->line());
             }
         }
         else
@@ -220,17 +220,17 @@ int nx::Nexus::run()
         auto const test_time_ms = std::chrono::duration<double>(end - start).count() * 1000;
         total_time_ms += test_time_ms;
 
-        LOGD(Nexus, Info, "  %<60s ... %6d checks in %.4f ms", t->name(), t->mAssertions, test_time_ms);
+        LOG("  %<60s ... %6d checks in %.4f ms", t->name(), t->mAssertions, test_time_ms);
     }
 
-    LOGD(Nexus, Info, "==============================================================================");
-    LOGD(Nexus, Info, "passed %d of %d %s in %.4f ms%s", //
+    LOG("==============================================================================");
+    LOG("passed %d of %d %s in %.4f ms%s", //
          tests_to_run.size() - fails, tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests", total_time_ms,
          fails == 0 ? "" : cc::format(" (%d failed)", fails));
-    LOGD(Nexus, Info, "checked %d assertions%s", assertions, failed_assertions == 0 ? "" : cc::format(" (%d failed)", failed_assertions));
+    LOG("checked %d assertions%s", assertions, failed_assertions == 0 ? "" : cc::format(" (%d failed)", failed_assertions));
     if (tests.empty())
     {
-        LOGD(Nexus, Warning, "no tests found/selected");
+        LOG_WARN("no tests found/selected");
         return EXIT_SUCCESS;
     }
     else if (fails > 0)
@@ -252,15 +252,15 @@ int nx::Nexus::run()
                     }
                     repr += "))";
                 }
-                LOGD(Nexus, Warning, "test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
+                LOG_WARN("test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
             }
-        LOGD(Nexus, Warning, "%d %s failed", failed_assertions, failed_assertions == 1 ? "ASSERTION" : "ASSERTIONS");
-        LOGD(Nexus, Warning, "%d %s failed", fails, fails == 1 ? "TEST" : "TESTS");
+        LOG_WARN("%d %s failed", failed_assertions, failed_assertions == 1 ? "ASSERTION" : "ASSERTIONS");
+        LOG_WARN("%d %s failed", fails, fails == 1 ? "TEST" : "TESTS");
         return EXIT_FAILURE;
     }
     else
     {
-        LOGD(Nexus, Info, "success.");
+        LOG("success.");
         if (!empty_tests.empty())
         {
             cc::string warn_log;
@@ -273,7 +273,7 @@ int nx::Nexus::run()
                 cc::format_to(warn_log, "    in %s:%s\n", t->file(), t->line());
             }
             warn_log.pop_back();
-            LOGD(Nexus, Warning, "%s", warn_log);
+            LOG_WARN("%s", warn_log);
         }
 
         return EXIT_SUCCESS;

--- a/src/nexus/Nexus.cc
+++ b/src/nexus/Nexus.cc
@@ -70,15 +70,15 @@ int nx::Nexus::run()
 
     if (mPrintHelp)
     {
-        LOG("version %s", version);
-        LOG("");
-        LOG("usage:");
-        LOG(R"(  --help        shows this help)");
-        LOG(R"(  "test name"   runs all tests named "test name" (quotation marks optional if no space in name))");
-        LOG("");
-        LOG("stats:");
-        LOG(" - found %s tests", detail::get_all_tests().size());
-        LOG(" - found %s apps", detail::get_all_apps().size());
+        RICH_LOG("version %s", version);
+        RICH_LOG("");
+        RICH_LOG("usage:");
+        RICH_LOG(R"(  --help        shows this help)");
+        RICH_LOG(R"(  "test name"   runs all tests named "test name" (quotation marks optional if no space in name))");
+        RICH_LOG("");
+        RICH_LOG("stats:");
+        RICH_LOG(" - found %s tests", detail::get_all_tests().size());
+        RICH_LOG(" - found %s apps", detail::get_all_apps().size());
 
         return EXIT_SUCCESS;
     }
@@ -149,13 +149,13 @@ int nx::Nexus::run()
         tests_to_run.push_back(t.get());
     }
 
-    LOG("version %s", version);
-    LOG("run with '--help' for options");
-    LOG("detected %s %s", tests.size(), tests.size() == 1 ? "test" : "tests");
-    LOG("running %s %s%s", tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests",
+    RICH_LOG("version %s", version);
+    RICH_LOG("run with '--help' for options");
+    RICH_LOG("detected %s %s", tests.size(), tests.size() == 1 ? "test" : "tests");
+    RICH_LOG("running %s %s%s", tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests",
         disabled_tests == 0 ? "" : cc::format(" (%s disabled)", disabled_tests));
-    LOG("TEST(..., seed(%s))", seed);
-    LOG("==============================================================================");
+    RICH_LOG("TEST(..., seed(%s))", seed);
+    RICH_LOG("==============================================================================");
 
     // execute tests
     // TODO: timings and statistics and so on
@@ -207,7 +207,7 @@ int nx::Nexus::run()
             if (!t->didFail())
             {
                 num_failed_tests++;
-                LOG_WARN("Test [%s] should have failed but didn't.\n  in %s:%s", t->name(), t->file(), t->line());
+                RICH_LOG_WARN("Test [%s] should have failed but didn't.\n  in %s:%s", t->name(), t->file(), t->line());
             }
         }
         else
@@ -231,18 +231,18 @@ int nx::Nexus::run()
         auto const test_time_ms = std::chrono::duration<double>(end - start).count() * 1000;
         total_time_ms += test_time_ms;
 
-        LOG("  %<60s ... %6d checks in %.4f ms", t->name(), num_checks, test_time_ms);
+        RICH_LOG("  %<60s ... %6d checks in %.4f ms", t->name(), num_checks, test_time_ms);
     }
 
-    LOG("==============================================================================");
-    LOG("passed %d of %d %s in %.4f ms%s", //
+    RICH_LOG("==============================================================================");
+    RICH_LOG("passed %d of %d %s in %.4f ms%s", //
         tests_to_run.size() - num_failed_tests, tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests", total_time_ms,
         num_failed_tests == 0 ? "" : cc::format(" (%d failed)", num_failed_tests));
-    LOG("checked %d assertions%s", total_num_checks, total_num_failed_checks == 0 ? "" : cc::format(" (%d failed)", total_num_failed_checks));
+    RICH_LOG("checked %d assertions%s", total_num_checks, total_num_failed_checks == 0 ? "" : cc::format(" (%d failed)", total_num_failed_checks));
 
     if (tests.empty())
     {
-        LOG_WARN("no tests found/selected");
+        RICH_LOG_WARN("no tests found/selected");
         return EXIT_SUCCESS;
     }
     else if (num_failed_tests > 0)
@@ -264,18 +264,18 @@ int nx::Nexus::run()
                     }
                     repr += "))";
                 }
-                LOG_WARN("test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
-                LOG_WARN("  %s:%s", t->file(), t->line());
+                RICH_LOG_WARN("test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
+                RICH_LOG_WARN("  %s:%s", t->file(), t->line());
             }
 
-        LOG_WARN("%d %s failed", total_num_failed_checks, total_num_failed_checks == 1 ? "ASSERTION" : "ASSERTIONS");
-        LOG_WARN("%d %s failed", num_failed_tests, num_failed_tests == 1 ? "TEST" : "TESTS");
+        RICH_LOG_WARN("%d %s failed", total_num_failed_checks, total_num_failed_checks == 1 ? "ASSERTION" : "ASSERTIONS");
+        RICH_LOG_WARN("%d %s failed", num_failed_tests, num_failed_tests == 1 ? "TEST" : "TESTS");
 
         return EXIT_FAILURE;
     }
     else
     {
-        LOG("success.");
+        RICH_LOG("success.");
         if (!empty_tests.empty())
         {
             cc::string warn_log;
@@ -288,7 +288,7 @@ int nx::Nexus::run()
                 cc::format_to(warn_log, "    in %s:%s\n", t->file(), t->line());
             }
             warn_log.pop_back();
-            LOG_WARN("%s", warn_log);
+            RICH_LOG_WARN("%s", warn_log);
         }
 
         return EXIT_SUCCESS;

--- a/src/nexus/Nexus.cc
+++ b/src/nexus/Nexus.cc
@@ -4,6 +4,7 @@
 #include <nexus/check.hh>
 #include <nexus/detail/assertions.hh>
 #include <nexus/detail/exception.hh>
+#include <nexus/detail/log.hh>
 #include <nexus/tests/Test.hh>
 
 #include <clean-core/hash.hh>
@@ -11,12 +12,10 @@
 #include <clean-core/unique_ptr.hh>
 
 #include <chrono>
+#include <cstdlib>
 #include <thread>
 
-// TODO: proper log
-#include <iomanip>
-#include <iostream>
-#include <sstream>
+#include <rich-log/log.hh>
 
 namespace
 {
@@ -71,17 +70,16 @@ int nx::Nexus::run()
 
     if (mPrintHelp)
     {
-        std::cout << "[nexus] version " << version << std::endl;
-        std::cout << "NOTE: nexus is still early in development." << std::endl;
-        std::cout << std::endl;
-        std::cout << "usage:" << std::endl;
-        std::cout << R"(  --help        shows this help)" << std::endl;
-        std::cout << R"(  "test name"   runs all tests named "test name" (quotation marks optional if no space in name))" << std::endl;
-        std::cout << std::endl;
-        std::cout << "stats:" << std::endl;
-        std::cout << "  - found " << detail::get_all_tests().size() << " tests" << std::endl;
-        std::cout << "  - found " << detail::get_all_apps().size() << " apps" << std::endl;
-        std::cout << std::endl;
+        LOGD(Nexus, Info, "version %s", version);
+        LOGD(Nexus, Info, "");
+        LOGD(Nexus, Info, "usage:");
+        LOGD(Nexus, Info, R"(  --help        shows this help)");
+        LOGD(Nexus, Info, R"(  "test name"   runs all tests named "test name" (quotation marks optional if no space in name))");
+        LOGD(Nexus, Info, "");
+        LOGD(Nexus, Info, "stats:");
+        LOGD(Nexus, Info, " - found %s tests", detail::get_all_tests().size());
+        LOGD(Nexus, Info, " - found %s apps", detail::get_all_apps().size());
+
         return EXIT_SUCCESS;
     }
 
@@ -151,17 +149,13 @@ int nx::Nexus::run()
         tests_to_run.push_back(t.get());
     }
 
-    std::cout << "[nexus] version " << version << std::endl;
-    std::cout << "[nexus] run with '--help' for options" << std::endl;
-    std::cout << "[nexus] detected " << tests.size() << (tests.size() == 1 ? " test" : " tests") << std::endl;
-    std::cout << "[nexus] running " << tests_to_run.size() << (tests_to_run.size() == 1 ? " test" : " tests");
-    if (disabled_tests > 0)
-        std::cout << " (" << disabled_tests << " disabled)";
-    std::cout << std::endl;
-    std::cout << "[nexus] TEST(..., seed(" << seed << "))" << std::endl;
-    std::cout << "==============================================================================" << std::endl;
-    std::cout << std::setprecision(4);
-    // TODO
+    LOGD(Nexus, Info, "version %s", version);
+    LOGD(Nexus, Info, "run with '--help' for options");
+    LOGD(Nexus, Info, "detected %s %s", tests.size(), tests.size() == 1 ? "test" : "tests");
+    LOGD(Nexus, Info, "running %s %s%s", tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests",
+         disabled_tests == 0 ? "" : cc::format(" (%s disabled)", disabled_tests));
+    LOGD(Nexus, Info, "TEST(..., seed(%s))", seed);
+    LOGD(Nexus, Info, "==============================================================================");
 
     // execute tests
     // TODO: timings and statistics and so on
@@ -179,7 +173,6 @@ int nx::Nexus::run()
         detail::always_terminate() = false;
 
         // execute and measure
-        auto const start_thread = std::this_thread::get_id();
         auto const start = std::chrono::high_resolution_clock::now();
         if (t->isDebug())
             t->function()();
@@ -195,7 +188,6 @@ int nx::Nexus::run()
             }
         }
         auto const end = std::chrono::high_resolution_clock::now();
-        auto const end_thread = std::this_thread::get_id();
 
         // report
         curr_test() = nullptr;
@@ -206,8 +198,7 @@ int nx::Nexus::run()
             if (!t->hasFailed())
             {
                 fails++;
-                std::cerr << "Test [" << t->name() << "] should have failed but didn't." << std::endl;
-                std::cerr << "  in " << t->file() << ":" << t->line() << std::endl;
+                LOGD(Nexus, Warning, "Test [%s] should have failed but didn't.\n  in %s:%s", t->name(), t->file(), t->line());
             }
         }
         else
@@ -229,26 +220,17 @@ int nx::Nexus::run()
         auto const test_time_ms = std::chrono::duration<double>(end - start).count() * 1000;
         total_time_ms += test_time_ms;
 
-        printf("  %-60s ... %6d checks in %.4f ms\n", t->name(), t->mAssertions, test_time_ms);
-        if (start_thread != end_thread)
-            std::cerr << " (WARNING: changed OS thread, from " << start_thread << " to " << end_thread << ")" << std::endl;
+        LOGD(Nexus, Info, "  %<60s ... %6d checks in %.4f ms", t->name(), t->mAssertions, test_time_ms);
     }
 
-    std::cout.flush();
-    std::cerr.flush();
-    std::cout << "==============================================================================" << std::endl;
-    std::cout << "[nexus] passed " << tests_to_run.size() - fails << " of " << tests_to_run.size() << (tests_to_run.size() == 1 ? " test" : " tests")
-              << " in " << total_time_ms << " ms";
-    if (fails > 0)
-        std::cout << " (" << fails << " failed)";
-    std::cout << std::endl;
-    std::cout << "[nexus] checked " << assertions << " assertions";
-    if (failed_assertions > 0)
-        std::cout << " (" << failed_assertions << " failed)";
-    std::cout << std::endl;
+    LOGD(Nexus, Info, "==============================================================================");
+    LOGD(Nexus, Info, "passed %d of %d %s in %.4f ms%s", //
+         tests_to_run.size() - fails, tests_to_run.size(), tests_to_run.size() == 1 ? "test" : "tests", total_time_ms,
+         fails == 0 ? "" : cc::format(" (%d failed)", fails));
+    LOGD(Nexus, Info, "checked %d assertions%s", assertions, failed_assertions == 0 ? "" : cc::format(" (%d failed)", failed_assertions));
     if (tests.empty())
     {
-        std::cerr << "[nexus] WARNING: no tests found/selected" << std::endl;
+        LOGD(Nexus, Warning, "no tests found/selected");
         return EXIT_SUCCESS;
     }
     else if (fails > 0)
@@ -256,32 +238,42 @@ int nx::Nexus::run()
         for (auto const& t : tests)
             if (t->hasFailed() != t->shouldFail())
             {
-                std::cerr << "[nexus] test [" << t->name() << "] failed (seed " << t->seed();
+                cc::string repr;
                 if (t->shouldReproduce())
                 {
-                    std::cerr << ", reproduce via TEST(..., reproduce(";
+                    repr += ", reproduce via TEST(..., reproduce(";
                     if (t->reproduction().trace.empty())
-                        std::cerr << t->reproduction().seed;
+                        repr += cc::to_string(t->reproduction().seed);
                     else
-                        std::cerr << '"' << t->reproduction().trace.c_str() << '"';
-                    std::cerr << "))";
+                    {
+                        repr += '"';
+                        repr += t->reproduction().trace;
+                        repr += '"';
+                    }
+                    repr += "))";
                 }
-                std::cerr << ")" << std::endl;
+                LOGD(Nexus, Warning, "test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
             }
-        std::cerr << "[nexus] ERROR: " << failed_assertions << " ASSERTION" << (failed_assertions == 1 ? "" : "S") << " FAILED" << std::endl;
-        std::cerr << "[nexus] ERROR: " << fails << " TEST" << (fails == 1 ? "" : "S") << " FAILED" << std::endl;
+        LOGD(Nexus, Warning, "%d %s failed", failed_assertions, failed_assertions == 1 ? "ASSERTION" : "ASSERTIONS");
+        LOGD(Nexus, Warning, "%d %s failed", fails, fails == 1 ? "TEST" : "TESTS");
         return EXIT_FAILURE;
     }
     else
     {
-        std::cout << "[nexus] success." << std::endl;
+        LOGD(Nexus, Info, "success.");
         if (!empty_tests.empty())
         {
-            std::cerr << "[nexus] WARNING: " << empty_tests.size() << " test(s) have no assertions." << std::endl;
-            std::cerr << "[nexus]   (this can indicate a bug and can be silenced with \"CHECK(true);\")" << std::endl;
-            std::cerr << "[nexus]   affected tests:" << std::endl;
+            cc::string warn_log;
+            cc::format_to(warn_log, "%d test(s) have no assertions.\n", empty_tests.size());
+            warn_log += "(this can indicate a bug and can be silenced with \"CHECK(true);\")\n";
+            warn_log += "affected tests:\n";
             for (auto t : empty_tests)
-                std::cerr << "[nexus]   - [" << t->name() << "]" << std::endl;
+            {
+                cc::format_to(warn_log, "  - [%s]\n", t->name());
+                cc::format_to(warn_log, "    in %s:%s\n", t->file(), t->line());
+            }
+            warn_log.pop_back();
+            LOGD(Nexus, Warning, "%s", warn_log);
         }
 
         return EXIT_SUCCESS;

--- a/src/nexus/Nexus.cc
+++ b/src/nexus/Nexus.cc
@@ -253,6 +253,7 @@ int nx::Nexus::run()
                     repr += "))";
                 }
                 LOG_WARN("test [%s] failed (seed %d%s)", t->name(), t->seed(), repr);
+                LOG_WARN("  %s:%s", t->file(), t->line());
             }
         LOG_WARN("%d %s failed", failed_assertions, failed_assertions == 1 ? "ASSERTION" : "ASSERTIONS");
         LOG_WARN("%d %s failed", fails, fails == 1 ? "TEST" : "TESTS");

--- a/src/nexus/args.cc
+++ b/src/nexus/args.cc
@@ -517,4 +517,29 @@ bool has_cmd_arg(cc::string_view arg)
     return false;
 }
 
+cc::string_view get_cmd_arg_value(cc::string_view arg)
+{
+    auto const curr_cmd_args = get_cmd_args();
+    int const argc = int(curr_cmd_args.size());
+    char const* const* argv = curr_cmd_args.data();
+
+    // only iterate to the (n - 1)th arg
+    for (auto i = 0; i < argc - 1; ++i)
+    {
+        if (!arg.equals(argv[i]))
+            continue; // flag does not match
+
+        char const* next_arg = argv[i + 1];
+
+        if (!next_arg || next_arg[0] == '\0' || next_arg[0] == '-')
+        {
+            // the flag exists but its next argument is empty or starts with a dash as well
+            return {};
+        }
+
+        return cc::string_view(next_arg);
+    }
+
+    return {};
+}
 }

--- a/src/nexus/args.cc
+++ b/src/nexus/args.cc
@@ -52,7 +52,7 @@ bool args::parse()
     if (auto a = nx::detail::get_current_app())
         return parse(a->argc(), a->argv());
 
-    LOG_ERROR("no-arg version can only be used inside Nexus Apps" );
+    RICH_LOG_ERROR("no-arg version can only be used inside Nexus Apps" );
     return false;
 }
 
@@ -130,13 +130,13 @@ bool args::parse(int argc, char const* const* argv)
                     }
                     else if (has_value)
                     {
-                        LOG_ERROR("argument `--%s' has a value but should not have one.", s );
+                        RICH_LOG_ERROR("argument `--%s' has a value but should not have one.", s );
                         return false;
                     }
                     return true;
                 }
 
-        LOG_ERROR("unknown argument `--%s'", s);
+        RICH_LOG_ERROR("unknown argument `--%s'", s);
         return false;
     };
 
@@ -183,7 +183,7 @@ bool args::parse(int argc, char const* const* argv)
 
             if (!ar)
             {
-                LOG_ERROR("unknown argument `-%s'", s[i]);
+                RICH_LOG_ERROR("unknown argument `-%s'", s[i]);
                 return false;
             }
         }
@@ -236,7 +236,7 @@ bool args::parse(int argc, char const* const* argv)
 
     if (valarg)
     {
-        LOG_ERROR("unexpected end of arguments. expected value after `%s'", argv[argc - 1]);
+        RICH_LOG_ERROR("unexpected end of arguments. expected value after `%s'", argv[argc - 1]);
         return false;
     }
 
@@ -255,7 +255,7 @@ bool args::parse(int argc, char const* const* argv)
 
         if (blocked_args.contains(a.a))
         {
-            LOG_ERROR("argument `%s' was provided multiple times (this is only allowed for boolean/flag args)", a.a->names.front());
+            RICH_LOG_ERROR("argument `%s' was provided multiple times (this is only allowed for boolean/flag args)", a.a->names.front());
             return false;
         }
 
@@ -286,7 +286,7 @@ bool args::parse(int argc, char const* const* argv)
     {
         if (!v.fun())
         {
-            LOG_ERROR("validation failed: %s", v.desc);
+            RICH_LOG_ERROR("validation failed: %s", v.desc);
             return false;
         }
     }
@@ -504,7 +504,7 @@ cc::span<const char* const> get_cmd_args()
     }
     else
     {
-        LOG_WARN("nx::get_cmd_args() was called outside of an active app or test\n");
+        RICH_LOG_WARN("nx::get_cmd_args() was called outside of an active app or test\n");
         return {};
     }
 }

--- a/src/nexus/args.cc
+++ b/src/nexus/args.cc
@@ -1,13 +1,16 @@
 #include "args.hh"
 
-#include <cstdio>
+// TODO: remove me (currently used for printing help, could be replaced by cc::print)
 #include <iostream>
+
+#include <rich-log/log.hh>
 
 #include <clean-core/pair.hh>
 #include <clean-core/set.hh>
 
 #include <nexus/apps/App.hh>
 #include <nexus/tests/Test.hh>
+#include <nexus/detail/log.hh>
 
 namespace nx
 {
@@ -49,7 +52,7 @@ bool args::parse()
     if (auto a = nx::detail::get_current_app())
         return parse(a->argc(), a->argv());
 
-    std::cerr << "no-arg version can only be used inside Nexus Apps" << std::endl;
+    LOG_ERROR("no-arg version can only be used inside Nexus Apps" );
     return false;
 }
 
@@ -127,13 +130,13 @@ bool args::parse(int argc, char const* const* argv)
                     }
                     else if (has_value)
                     {
-                        std::cerr << "argument `--" << cc::string(s).c_str() << "' has a value but should not have one." << std::endl;
+                        LOG_ERROR("argument `--%s' has a value but should not have one.", s );
                         return false;
                     }
                     return true;
                 }
 
-        std::cerr << "unknown argument `--" << cc::string(s).c_str() << "'" << std::endl;
+        LOG_ERROR("unknown argument `--%s'", s);
         return false;
     };
 
@@ -180,7 +183,7 @@ bool args::parse(int argc, char const* const* argv)
 
             if (!ar)
             {
-                std::cerr << "unknown argument `-" << s[i] << "'" << std::endl;
+                LOG_ERROR("unknown argument `-%s'", s[i]);
                 return false;
             }
         }
@@ -233,7 +236,7 @@ bool args::parse(int argc, char const* const* argv)
 
     if (valarg)
     {
-        std::cerr << "unexpected end of arguments. expected value after `" << argv[argc - 1] << "'" << std::endl;
+        LOG_ERROR("unexpected end of arguments. expected value after `%s'", argv[argc - 1]);
         return false;
     }
 
@@ -252,7 +255,7 @@ bool args::parse(int argc, char const* const* argv)
 
         if (blocked_args.contains(a.a))
         {
-            std::cerr << "argument `" << a.a->names.front().c_str() << "' was provided multiple times (this is only allowed for boolean/flag args)" << std::endl;
+            LOG_ERROR("argument `%s' was provided multiple times (this is only allowed for boolean/flag args)", a.a->names.front());
             return false;
         }
 
@@ -283,7 +286,7 @@ bool args::parse(int argc, char const* const* argv)
     {
         if (!v.fun())
         {
-            std::cerr << "validation failed: " << v.desc.c_str() << std::endl;
+            LOG_ERROR("validation failed: %s", v.desc);
             return false;
         }
     }
@@ -501,7 +504,7 @@ cc::span<const char* const> get_cmd_args()
     }
     else
     {
-        std::fprintf(stderr, "[nexus] warning: nx::get_cmd_args() was called outside of an active app or test\n");
+        LOG_WARN("nx::get_cmd_args() was called outside of an active app or test\n");
         return {};
     }
 }

--- a/src/nexus/args.hh
+++ b/src/nexus/args.hh
@@ -272,4 +272,9 @@ NX_API cc::span<char const* const> get_cmd_args();
 
 /// returns true if the current test or app was launched with the given command line argument
 NX_API bool has_cmd_arg(cc::string_view arg);
+
+/// returns the value of the given argument on the command line (or an empty string view)
+/// requires syntax like --<flag> <value>
+/// where <value> does not begin with '-'
+NX_API cc::string_view get_cmd_arg_value(cc::string_view arg);
 }

--- a/src/nexus/check.cc
+++ b/src/nexus/check.cc
@@ -31,5 +31,5 @@ bool nx::detail::report_failed_check(nx::detail::check_result const& r, const ch
             std::cerr << "  in function " << function << std::endl;
     }
 
-    return terminate || nx::detail::always_terminate() || t->isDebug();
+    return terminate || nx::detail::always_terminate() || t->isDebug() || t->shouldReproduce();
 }

--- a/src/nexus/check.hh
+++ b/src/nexus/check.hh
@@ -10,6 +10,7 @@
 #include <nexus/detail/api.hh>
 #include <nexus/detail/exception.hh>
 #include <nexus/detail/make_string_repr.hh>
+#include <nexus/range.hh>
 
 #ifndef NX_FORCE_MACRO_PREFIX
 

--- a/src/nexus/check.hh
+++ b/src/nexus/check.hh
@@ -72,6 +72,12 @@ inline int& number_of_failed_assertions()
     return cnt;
 }
 
+struct local_check_counters
+{
+    int num_checks = 0;
+    int num_failed_checks = 0;
+};
+
 struct NX_API check_result
 {
     bool is_true = false;

--- a/src/nexus/detail/log.cc
+++ b/src/nexus/detail/log.cc
@@ -1,3 +1,6 @@
 #include "log.hh"
 
-RICH_LOG_DEFINE_DOMAIN(Nexus);
+namespace nx
+{
+RICH_LOG_DEFINE_DEFAULT_DOMAIN("nexus");
+}

--- a/src/nexus/detail/log.cc
+++ b/src/nexus/detail/log.cc
@@ -1,0 +1,3 @@
+#include "log.hh"
+
+RICH_LOG_DEFINE_DOMAIN(Nexus);

--- a/src/nexus/detail/log.hh
+++ b/src/nexus/detail/log.hh
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <rich-log/domain.hh>
+
+RICH_LOG_DECLARE_DOMAIN(Nexus);

--- a/src/nexus/detail/log.hh
+++ b/src/nexus/detail/log.hh
@@ -2,4 +2,7 @@
 
 #include <rich-log/domain.hh>
 
-RICH_LOG_DECLARE_DOMAIN(Nexus);
+namespace nx
+{
+RICH_LOG_DECLARE_DEFAULT_DOMAIN();
+}

--- a/src/nexus/detail/trace_serialize.cc
+++ b/src/nexus/detail/trace_serialize.cc
@@ -79,7 +79,7 @@ cc::vector<int> nx::detail::trace_decode(cc::string_view encoded_string)
 
     cc::vector<int> v;
 
-    while (pos < encoded_string.size())
+    while (pos < int(encoded_string.size()))
         v.push_back(read_int());
 
     return v;

--- a/src/nexus/fuzz_test.cc
+++ b/src/nexus/fuzz_test.cc
@@ -42,7 +42,7 @@ void nx::detail::execute_fuzz_test(void (*f)(tg::rng&))
     };
 
     if (test->isEndless())
-        LOG("endless FUZZ_TEST(\"%s\")", test->name());
+        RICH_LOG("endless FUZZ_TEST(\"%s\")", test->name());
 
     auto c_start = cc::intrin_rdtsc();
     auto it = 0;
@@ -79,7 +79,7 @@ void nx::detail::execute_fuzz_test(void (*f)(tg::rng&))
             if (t1 - t0 > 1000ms)
             {
                 t0 = t1;
-                LOG("endless FUZZ_TEST: %s assertions", nx::detail::number_of_assertions() - assert_cnt_start);
+                RICH_LOG("endless FUZZ_TEST: %s assertions", nx::detail::number_of_assertions() - assert_cnt_start);
             }
 
             continue;

--- a/src/nexus/fuzz_test.cc
+++ b/src/nexus/fuzz_test.cc
@@ -1,12 +1,15 @@
 #include "fuzz_test.hh"
 
-#include <iostream> // TODO: proper log
+#include <rich-log/log.hh>
+
+#include <chrono>
 
 #include <clean-core/defer.hh>
 #include <clean-core/intrinsics.hh>
 
 #include <nexus/detail/assertions.hh>
 #include <nexus/detail/exception.hh>
+#include <nexus/detail/log.hh>
 #include <nexus/tests/Test.hh>
 
 
@@ -38,8 +41,13 @@ void nx::detail::execute_fuzz_test(void (*f)(tg::rng&))
         nx::detail::reset_assertion_handlers();
     };
 
+    if (test->isEndless())
+        LOG("endless FUZZ_TEST(\"%s\")", test->name());
+
     auto c_start = cc::intrin_rdtsc();
     auto it = 0;
+    auto assert_cnt_start = nx::detail::number_of_assertions();
+    auto t0 = std::chrono::high_resolution_clock::now();
     while (true)
     {
         auto seed = base_rng();
@@ -57,8 +65,6 @@ void nx::detail::execute_fuzz_test(void (*f)(tg::rng&))
             }
             catch (assertion_failed_exception const&)
             {
-                std::cerr << "[nexus] fuzz test [" << test->name() << "] failed." << std::endl;
-                std::cerr << "        (reproduce via TEST(..., reproduce(" << seed << ")) " << std::endl;
                 test->setReproduce(reproduce(seed));
                 return;
             }
@@ -66,7 +72,18 @@ void nx::detail::execute_fuzz_test(void (*f)(tg::rng&))
         ++it;
 
         if (test->isEndless())
+        {
+            // progress report
+            auto t1 = std::chrono::high_resolution_clock::now();
+            using namespace std::chrono_literals;
+            if (t1 - t0 > 1000ms)
+            {
+                t0 = t1;
+                LOG("endless FUZZ_TEST: %s assertions", nx::detail::number_of_assertions() - assert_cnt_start);
+            }
+
             continue;
+        }
 
         if (it > max_iterations)
             break;

--- a/src/nexus/fwd.hh
+++ b/src/nexus/fwd.hh
@@ -2,7 +2,14 @@
 
 namespace nx
 {
+namespace detail
+{
+struct local_check_counters;
+}
+
 using test_fun_t = void (*)();
+using test_fun_before_t = void (*)();
+using test_fun_after_t = void (*)(detail::local_check_counters*);
 using app_fun_t = void (*)();
 
 class Test;

--- a/src/nexus/fwd.hh
+++ b/src/nexus/fwd.hh
@@ -14,6 +14,7 @@ using app_fun_t = void (*)();
 
 class Test;
 class App;
+class MonteCarloTest;
 
 template <class T>
 struct minimize_options;

--- a/src/nexus/minimize.hh
+++ b/src/nexus/minimize.hh
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <nexus/minimize_options.hh>
+
+namespace nx
+{
+/// generic minimization of a test case
+/// takes an input test case (any type)
+///       an option generator (function from T -> minimize_options<T>)
+///       an is_failing predicate (function from T -> bool)
+/// returns a minimized version of T that is failing (if the input is failing)
+///
+/// NOTE: options must not generate cycles!
+///       it is understood that each provided option is "smaller" in the user-desired sense
+///       and "smaller" is well-founded
+///
+/// NOTE: the functions can also accept T const&
+///       this arg is guaranteed to surpass the lifetime of the returning minimize_options<T>
+template <class T, class OptionGeneratorF, class IsFailingF>
+T minimize(T input, OptionGeneratorF&& generate_options, IsFailingF&& is_failing)
+{
+    static_assert(std::is_invocable_r_v<minimize_options<T>, OptionGeneratorF, T>);
+    static_assert(std::is_invocable_r_v<bool, IsFailingF, T>);
+
+    while (true)
+    {
+        minimize_options<T> opts = generate_options(input);
+
+        auto has_smaller = false;
+        while (opts.has_options_left())
+        {
+            T smaller_input = opts.get_next_option_for(input);
+            if (is_failing(smaller_input))
+            {
+                input = cc::move(smaller_input);
+                has_smaller = true;
+                break;
+            }
+        }
+
+        if (!has_smaller)
+            break;
+    }
+
+    return input;
+}
+}

--- a/src/nexus/range.hh
+++ b/src/nexus/range.hh
@@ -60,6 +60,8 @@ private:
     size_t _size;
 };
 
+// C++20's rewrite rules makes this ambiguous
+#if __cplusplus < 202002L
 template <class Range, class T>
 bool operator==(Range const& lhs, range<T> const& rhs)
 {
@@ -70,4 +72,5 @@ bool operator!=(Range const& lhs, range<T> const& rhs)
 {
     return rhs.operator!=(lhs);
 }
+#endif
 }

--- a/src/nexus/range.hh
+++ b/src/nexus/range.hh
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <cstddef>
+#include <initializer_list>
+
+#include <nexus/detail/make_string_repr.hh>
+
+namespace nx
+{
+/// convenience function to CHECK ranges/iterables
+/// usage:
+///
+///   cc::vector<int> v = ...;
+///   CHECK(v == nx::range{1,2,3});
+///   CHECK(v == nx::range<size_t>{1,2,3});
+///
+/// NOTE: do not save this class. it is only intended to be used within CHECK
+///
+template <class T>
+struct range
+{
+    range(std::initializer_list<T> vals)
+    {
+        _data = vals.begin();
+        _size = vals.size();
+    }
+
+    T const* begin() const { return _data; }
+    T const* end() const { return _data + _size; }
+    size_t size() const { return _size; }
+
+    template <class Range>
+    bool operator==(Range const& rhs) const
+    {
+        size_t i = 0;
+        for (auto const& v : rhs)
+        {
+            using U = std::decay_t<decltype(v)>;
+            static_assert(std::is_same_v<T, U>, "element types must match exactly to prevent errors");
+
+            if (i >= _size)
+                return false;
+
+            if (_data[i] != v)
+                return false;
+
+            ++i;
+        }
+
+        return i == _size;
+    }
+    template <class Range>
+    bool operator!=(Range const& rhs) const
+    {
+        return !operator==(rhs);
+    }
+
+private:
+    T const* _data;
+    size_t _size;
+};
+
+template <class Range, class T>
+bool operator==(Range const& lhs, range<T> const& rhs)
+{
+    return rhs.operator==(lhs);
+}
+template <class Range, class T>
+bool operator!=(Range const& lhs, range<T> const& rhs)
+{
+    return rhs.operator!=(lhs);
+}
+}

--- a/src/nexus/test.cc
+++ b/src/nexus/test.cc
@@ -38,6 +38,20 @@ size_t nx::get_seed()
     return t->seed();
 }
 
+bool nx::is_current_test_debug()
+{
+    auto t = nx::detail::get_current_test();
+    CC_ASSERT(t && "no active test");
+    return t->isDebug();
+}
+
+bool nx::is_current_test_reproduction()
+{
+    auto t = nx::detail::get_current_test();
+    CC_ASSERT(t && "no active test");
+    return t->shouldReproduce();
+}
+
 void detail::configure(Test* t, const endless_t&) { t->setEndless(); }
 
 void detail::configure(Test* t, const reproduce& r) { t->setReproduce(r); }

--- a/src/nexus/test.cc
+++ b/src/nexus/test.cc
@@ -69,5 +69,5 @@ void nx::print_current_test_reproduction()
 {
     auto t = nx::detail::get_current_test();
     CC_ASSERT(t && "no active test");
-    LOG("%s", t->makeCurrentReproductionCommand());
+    RICH_LOG("%s", t->makeCurrentReproductionCommand());
 }

--- a/src/nexus/test.cc
+++ b/src/nexus/test.cc
@@ -1,5 +1,8 @@
 #include "test.hh"
 
+#include <rich-log/log.hh>
+
+#include <nexus/detail/log.hh>
 #include <nexus/tests/Test.hh>
 
 #include <clean-core/unique_ptr.hh>
@@ -61,3 +64,10 @@ void detail::configure(Test* t, const disabled_t&) { t->setDisabled(); }
 void detail::configure(Test* t, const debug_t&) { t->setDebug(); }
 
 void detail::configure(Test* t, const verbose_t&) { t->setVerbose(); }
+
+void nx::print_current_test_reproduction()
+{
+    auto t = nx::detail::get_current_test();
+    CC_ASSERT(t && "no active test");
+    LOG("%s", t->makeCurrentReproductionCommand());
+}

--- a/src/nexus/test.cc
+++ b/src/nexus/test.cc
@@ -21,9 +21,9 @@ void nx::detail::configure(Test* t, exclusive_t const&) { t->setExclusive(); }
 
 void nx::detail::configure(Test* t, should_fail_t const&) { t->setShouldFail(); }
 
-Test* detail::register_test(const char* name, const char* file, int line, char const* fun_name, test_fun_t fun)
+Test* detail::register_test(const char* name, const char* file, int line, char const* fun_name, test_fun_t fun, test_fun_before_t fun_before, test_fun_after_t fun_after, local_check_counters* counters)
 {
-    auto t = cc::make_unique<Test>(name, file, line, fun_name, fun);
+    auto t = cc::make_unique<Test>(name, file, line, fun_name, fun, fun_before, fun_after, counters);
     auto t_ptr = t.get();
     get_all_tests().push_back(std::move(t));
     return t_ptr;

--- a/src/nexus/test.hh
+++ b/src/nexus/test.hh
@@ -71,6 +71,14 @@ namespace nx
 /// NOTE: only valid inside a test!
 NX_API size_t get_seed();
 
+/// true iff the current test is in debug mode
+/// NOTE: only valid inside a test!
+NX_API bool is_current_test_debug();
+
+/// true iff the current test is in reproduction mode
+/// NOTE: only valid inside a test!
+NX_API bool is_current_test_reproduction();
+
 namespace detail
 {
 NX_API Test* register_test(

--- a/src/nexus/test.hh
+++ b/src/nexus/test.hh
@@ -79,6 +79,11 @@ NX_API bool is_current_test_debug();
 /// NOTE: only valid inside a test!
 NX_API bool is_current_test_reproduction();
 
+/// prints a reproduction string for the current test
+/// NOTE: only works with MCTs currently
+/// NOTE: only valid inside a test!
+NX_API void print_current_test_reproduction();
+
 namespace detail
 {
 NX_API Test* register_test(

--- a/src/nexus/tests/MonteCarloTest.cc
+++ b/src/nexus/tests/MonteCarloTest.cc
@@ -467,9 +467,18 @@ void nx::MonteCarloTest::addPostSessionCallback(cc::unique_function<void()> f)
     mPostCallbacks.emplace_back(cc::move(f));
 }
 
+nx::MonteCarloTest::MonteCarloTest()
+{
+    auto t = nx::detail::get_current_test();
+    CC_ASSERT(t != nullptr && "only creatable during tests");
+    t->setMonteCarloTest(this);
+}
+
 void nx::MonteCarloTest::execute()
 {
     machine_trace trace;
+    mCurrentTrace = &trace;
+    CC_DEFER { mCurrentTrace = nullptr; };
 
     auto test = nx::detail::get_current_test();
 

--- a/src/nexus/tests/MonteCarloTest.cc
+++ b/src/nexus/tests/MonteCarloTest.cc
@@ -18,6 +18,7 @@
 
 #include <nexus/detail/assertions.hh>
 #include <nexus/detail/exception.hh>
+#include <nexus/detail/log.hh>
 #include <nexus/detail/trace_serialize.hh>
 #include <nexus/minimize_options.hh>
 #include <nexus/test.hh>
@@ -113,8 +114,8 @@ struct nx::MonteCarloTest::machine
                     if (fa->is_optional)
                         continue; // not strictly required
 
-                    LOG_ERROR("operation '{}' not found for type {}", name, tb.name());
-                    LOG_ERROR("(note: an exact match is required, subtyping may interfere with this)");
+                    LOGD(Nexus, Error, "operation '{}' not found for type {}", name, tb.name());
+                    LOGD(Nexus, Error, "(note: an exact match is required, subtyping may interfere with this)");
                 }
                 CC_ASSERT(eq_funs_by_type.get(tb).contains_key(name) && "all functions checked for equivalence need to be defined for both types");
                 auto fb = eq_funs_by_type.get(tb).get(name);
@@ -142,15 +143,15 @@ struct nx::MonteCarloTest::machine
                 if (f_a->return_type == e.type_a)
                 {
                     if (f_b->return_type != e.type_b)
-                        LOG_ERROR("bisimulation return type mismatch for '{}': expected {}, got {}", f_a->name, cc::demangle(e.type_b.name()),
-                                  cc::demangle(f_b->return_type.name()));
+                        LOGD(Nexus, Error, "bisimulation return type mismatch for '{}': expected {}, got {}", f_a->name,
+                             cc::demangle(e.type_b.name()), cc::demangle(f_b->return_type.name()));
                     CC_ASSERT(f_b->return_type == e.type_b);
                 }
                 else
                 {
                     if (f_a->return_type != f_b->return_type)
-                        LOG_ERROR("bisimulation return type mismatch for '{}': {} vs {}", f_a->name, cc::demangle(f_a->return_type.name()),
-                                  cc::demangle(f_b->return_type.name()));
+                        LOGD(Nexus, Error, "bisimulation return type mismatch for '{}': {} vs {}", f_a->name, cc::demangle(f_a->return_type.name()),
+                             cc::demangle(f_b->return_type.name()));
                     CC_ASSERT(f_a->return_type == f_b->return_type);
                 }
 
@@ -252,14 +253,14 @@ struct nx::MonteCarloTest::machine
             for (auto a : f->arg_types)
                 if (!values.get(a).can_safely_generate())
                 {
-                    LOG_ERROR("no way to generate type {}", a.name());
+                    LOGD(Nexus, Error, "no way to generate type {}", a.name());
                     return false;
                 }
 
         // sanity checks
         if (test_functions.empty())
         {
-            LOG_ERROR("no functions to test");
+            LOGD(Nexus, Error, "no functions to test");
             return false;
         }
 
@@ -309,7 +310,7 @@ struct nx::MonteCarloTest::machine
 
             if (--max_tries < 0)
             {
-                LOG_ERROR("unable to generate values of type {}", f->return_type.name());
+                LOGD(Nexus, Error, "unable to generate values of type {}", f->return_type.name());
                 return nullptr;
             }
         }
@@ -462,7 +463,7 @@ void nx::MonteCarloTest::execute()
     if (test->shouldReproduce())
     {
         CC_ASSERT(!test->reproduction().trace.empty() && "MCT needs a string reproduce (trace)");
-        LOG_ERROR("[nexus] replaying MCT trace '{}'", test->reproduction().trace);
+        LOGD(Nexus, Error, "[nexus] replaying MCT trace '{}'", test->reproduction().trace);
         auto trace = nx::detail::trace_decode(test->reproduction().trace);
         reproduceTrace(trace);
         return;
@@ -487,9 +488,9 @@ void nx::MonteCarloTest::execute()
     catch (nx::detail::assertion_failed_exception const&)
     {
         // on fail: try to minimize trace
-        LOG_ERROR("[nexus] MONTE_CARLO_TEST failed. Trying to generate minimal reproduction.");
+        LOGD(Nexus, Error, "[nexus] MONTE_CARLO_TEST failed. Trying to generate minimal reproduction.");
         minimizeTrace(trace);
-        LOG_ERROR("[nexus] .. done. result:");
+        LOGD(Nexus, Error, "[nexus] .. done. result:");
 
         // set reproduction BEFORE actually executing it
         test->setReproduce(reproduce(trace.serialize_to_string(*this)));
@@ -513,7 +514,7 @@ void nx::MonteCarloTest::tryExecuteMachineNormally(machine_trace& trace)
 
     // pre callbacks
     if (verbose)
-        LOG_INFO(" .. executing pre-callbacks ({})", mPreCallbacks.size());
+        LOGD(Nexus, Info, " .. executing pre-callbacks ({})", mPreCallbacks.size());
     for (auto& f : mPreCallbacks)
         f();
 
@@ -521,7 +522,7 @@ void nx::MonteCarloTest::tryExecuteMachineNormally(machine_trace& trace)
     CC_DEFER
     {
         if (verbose)
-            LOG_INFO(" .. executing post-callbacks ({})", mPreCallbacks.size());
+            LOGD(Nexus, Info, " .. executing post-callbacks ({})", mPreCallbacks.size());
         for (auto& f : mPostCallbacks)
             f();
     };
@@ -532,7 +533,7 @@ void nx::MonteCarloTest::tryExecuteMachineNormally(machine_trace& trace)
         CC_ASSERT(f->arity() == int(arg_indices.size()));
 
         if (verbose)
-            LOG_INFO(" .. execute [{}]", f->name);
+            LOGD(Nexus, Info, " .. execute [{}]", f->name);
 
         machine_trace::op op;
         op.function_idx = f->internal_idx;
@@ -562,9 +563,9 @@ void nx::MonteCarloTest::tryExecuteMachineNormally(machine_trace& trace)
         {
             if (unsuccessful_count > 1000)
             {
-                LOG_ERROR("unable to execute a test function (no precondition satisfied)");
+                LOGD(Nexus, Error, "unable to execute a test function (no precondition satisfied)");
                 for (auto f : m.test_functions)
-                    LOG_ERROR("  .. could not execute '{}'", f->name);
+                    LOGD(Nexus, Error, "  .. could not execute '{}'", f->name);
                 CHECK(false);
                 break;
             }
@@ -711,9 +712,9 @@ void nx::MonteCarloTest::tryExecuteMachineNormally(machine_trace& trace)
             {
                 if (unsuccessful_count > 1000)
                 {
-                    LOG_ERROR(" unable to execute a test function (no precondition satisfied)");
+                    LOGD(Nexus, Error, " unable to execute a test function (no precondition satisfied)");
                     for (auto f : m_a.test_functions)
-                        LOG_ERROR("  .. could not execute '{}'", f->name);
+                        LOGD(Nexus, Error, "  .. could not execute '{}'", f->name);
                     CHECK(false);
                     break;
                 }
@@ -769,7 +770,7 @@ void nx::MonteCarloTest::minimizeTrace(machine_trace& trace)
 
     while (found_smaller) // TODO: time limit
     {
-        LOG_ERROR("[nexus]   .. trace complexity {}", trace.complexity());
+        LOGD(Nexus, Error, "[nexus]   .. trace complexity {}", trace.complexity());
         auto opts = trace.build_minimizer();
 
         found_smaller = false;
@@ -797,16 +798,16 @@ void nx::MonteCarloTest::minimizeTrace(machine_trace& trace)
 bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode)
 {
     if (print_mode)
-        LOG_ERROR("[nexus] =============== TRACE BEGIN ===============");
+        LOGD(Nexus, Error, "[nexus] =============== TRACE BEGIN ===============");
     CC_DEFER
     {
         if (print_mode)
-            LOG_ERROR("[nexus] =============== TRACE END ===============");
+            LOGD(Nexus, Error, "[nexus] =============== TRACE END ===============");
     };
 
     // pre callbacks
     if (print_mode && !mPreCallbacks.empty())
-        LOG_ERROR("[nexus]   executing pre-callbacks");
+        LOGD(Nexus, Error, "[nexus]   executing pre-callbacks");
     for (auto& f : mPreCallbacks)
         f();
 
@@ -814,7 +815,7 @@ bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode
     CC_DEFER
     {
         if (print_mode && !mPostCallbacks.empty())
-            LOG_ERROR("[nexus]   executing post-callbacks");
+            LOGD(Nexus, Error, "[nexus]   executing post-callbacks");
         for (auto& f : mPostCallbacks)
             f();
     };
@@ -843,7 +844,7 @@ bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode
     // print symbolic execution
     if (print_mode)
     {
-        LOG_ERROR("[nexus] symbolic:");
+        LOGD(Nexus, Error, "[nexus] symbolic:");
         for (auto const& op : trace.ops)
         {
             cc::string s;
@@ -875,9 +876,9 @@ bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode
                 s += " : ";
                 s += cc::demangle(op.fun->return_type.name());
             }
-            LOG_ERROR("[nexus]   {}", s);
+            LOGD(Nexus, Error, "[nexus]   {}", s);
         }
-        LOG_ERROR("[nexus] actual:");
+        LOGD(Nexus, Error, "[nexus] actual:");
     }
     auto const print_inputs = [&value_to_string](function* f, cc::span<value*> args, cc::span<cc::string> vals)
     {
@@ -897,7 +898,7 @@ bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode
             }
             s += ")";
         }
-        LOG_ERROR("[nexus]   {}", s);
+        LOGD(Nexus, Error, "[nexus]   {}", s);
     };
     auto const print_outputs = [&value_to_string](cc::string_view prefix, function* f, value const& v, cc::span<value*> args, cc::span<const cc::string> vals)
     {
@@ -933,7 +934,7 @@ bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode
             s += " -> ";
             s += value_to_string(v);
         }
-        LOG_ERROR("[nexus]     {} {}", prefix, s);
+        LOGD(Nexus, Error, "[nexus]     {} {}", prefix, s);
     };
 
     // normal mode: no equivalence checking
@@ -1090,7 +1091,7 @@ bool nx::MonteCarloTest::replayTrace(machine_trace const& trace, bool print_mode
 
 void nx::MonteCarloTest::printSetup()
 {
-    LOG_INFO("registered functions:");
+    LOGD(Nexus, Info, "registered functions:");
     for (auto const& f : mFunctions)
     {
         cc::string s;
@@ -1106,7 +1107,7 @@ void nx::MonteCarloTest::printSetup()
         s += f.return_type.name();
         if (f.is_invariant)
             s += " [INVARIANT]";
-        LOG_INFO("  {}", s);
+        LOGD(Nexus, Info, "  {}", s);
     }
 }
 

--- a/src/nexus/tests/MonteCarloTest.cc
+++ b/src/nexus/tests/MonteCarloTest.cc
@@ -490,7 +490,7 @@ void nx::MonteCarloTest::execute()
     if (test->shouldReproduce())
     {
         CC_ASSERT(!test->reproduction().trace.empty() && "MCT needs a string reproduce (trace)");
-        LOG_ERROR("replaying MCT trace '{}'", test->reproduction().trace);
+        LOG_ERROR("replaying MCT trace '{}' for '{}'", test->reproduction().trace, test->name());
         auto trace = nx::detail::trace_decode(test->reproduction().trace);
         reproduceTrace(trace);
         return;

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -6,6 +6,7 @@
 
 #include <clean-core/capped_vector.hh>
 #include <clean-core/has_operator.hh>
+#include <clean-core/invoke.hh>
 #include <clean-core/map.hh>
 #include <clean-core/span.hh>
 #include <clean-core/string.hh>
@@ -178,7 +179,7 @@ private:
         static R apply(F&& f, [[maybe_unused]] cc::span<value*> inputs, std::index_sequence<I...>)
         {
             // TODO: proper rvalue ref support (maybe via forward?)
-            return f((*static_cast<std::decay_t<Args>*>(inputs[I]->ptr))...);
+            return cc::invoke(f, (*static_cast<std::decay_t<Args>*>(inputs[I]->ptr))...);
         }
     };
 
@@ -286,15 +287,40 @@ private:
         {
             CC_ASSERT(!precondition && "already has a precondition");
             static_assert(std::is_same_v<R, bool>, "precondition must return bool");
-            // check correct argument types
-            CC_ASSERT(sizeof...(Args) <= arg_types.size() && "precondition arguments must at most be as many as op arguments");
+
             cc::capped_vector<std::type_index, sizeof...(Args)> p_types;
             (p_types.emplace_back(typeid(std::decay_t<Args>)), ...);
-            for (size_t i = 0; i < sizeof...(Args); ++i)
-                CC_ASSERT(p_types[i] == arg_types[i] && "precondition arguments types must match op arguments");
 
-            precondition = [f = cc::forward<F>(f)](cc::span<value*> inputs) -> bool
-            { return executor<Args...>::template apply<bool>(f, inputs.subspan(0, sizeof...(Args)), std::index_sequence_for<Args...>()); };
+            // single-arg must only match at least one type
+            if constexpr (sizeof...(Args) == 1)
+            {
+                auto cnt = 0;
+                for (auto t : arg_types)
+                    if (t == p_types[0])
+                        ++cnt;
+                CC_ASSERT(cnt > 0 && "at least one type must apply. did the precondition not match properly?");
+
+                precondition = [p_type = cc::move(p_types[0]), f = cc::forward<F>(f)](cc::span<value*> inputs) -> bool { //
+                    for (auto v : inputs)
+                        if (v->type == p_type)
+                        {
+                            if (!cc::invoke(f, (*static_cast<std::decay_t<Args>*>(v->ptr))...))
+                                return false;
+                        }
+                    return true;
+                };
+            }
+            else
+            {
+                // check correct argument types
+                CC_ASSERT(sizeof...(Args) <= arg_types.size() && "precondition arguments must at most be as many as op arguments");
+                for (size_t i = 0; i < sizeof...(Args); ++i)
+                    CC_ASSERT(p_types[i] == arg_types[i] && "precondition arguments types must match op arguments");
+
+                precondition = [f = cc::forward<F>(f)](cc::span<value*> inputs) -> bool { //
+                    return executor<Args...>::template apply<bool>(f, inputs.subspan(0, sizeof...(Args)), std::index_sequence_for<Args...>());
+                };
+            }
         }
 
     private:

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -329,6 +329,7 @@ private:
             int function_idx = -1;
             int args_start_idx = -1;
             int return_value_idx = -1;
+            int seed = -1;
             function* fun = nullptr;
         };
 

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -14,8 +14,8 @@
 #include <clean-core/vector.hh>
 
 #include <nexus/check.hh>
-#include <nexus/detail/signature.hh>
 #include <nexus/detail/api.hh>
+#include <nexus/detail/signature.hh>
 #include <nexus/fwd.hh>
 
 #ifdef NX_HAS_REFLECTOR
@@ -92,6 +92,8 @@ public:
     }
 
     MonteCarloTest();
+    MonteCarloTest(MonteCarloTest const&) = delete;
+    MonteCarloTest& operator=(MonteCarloTest const&) = delete;
 
     // execution
 public:

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -83,6 +83,8 @@ public:
         mTypeMetadata[std::type_index(typeid(T))].to_string = [f = cc::move(f)](void* p) { return f(*static_cast<T const*>(p)); };
     }
 
+    MonteCarloTest();
+
     // execution
 public:
     void execute();
@@ -413,5 +415,9 @@ private:
     cc::vector<cc::unique_function<void()>> mPreCallbacks;
     cc::vector<cc::unique_function<void()>> mPostCallbacks;
     cc::vector<equivalence> mEquivalences;
+
+    machine_trace* mCurrentTrace = nullptr;
+
+    friend class Test;
 };
 }

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -14,6 +14,7 @@
 
 #include <nexus/check.hh>
 #include <nexus/detail/signature.hh>
+#include <nexus/detail/api.hh>
 #include <nexus/fwd.hh>
 
 #ifdef NX_HAS_REFLECTOR
@@ -24,7 +25,7 @@
 namespace nx
 {
 // TODO: allow when for a subset of arguments as long as it's unambiguous
-class MonteCarloTest
+class NX_API MonteCarloTest
 {
     // fwd
 private:

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -66,6 +66,13 @@ public:
     void addPreSessionCallback(cc::unique_function<void()> f);
     void addPostSessionCallback(cc::unique_function<void()> f);
 
+    /// adds a fixed reproduction that is re-run first on normal runs
+    /// e.g. if an MCT fail reports 'TEST(..., reproduce("--000-300.db1-200:ZZ01-200:7711-200-2-10")))'
+    ///      one could call addFixedReproduction("--000-300.db1-200:ZZ01-200:7711-200-2-10");
+    ///      so that this case is always run on normal executions
+    /// NOTE: the reproduction string is strongly coupled with the order of registered operations
+    void addFixedReproduction(cc::string reprString);
+
     template <class F>
     void testEquivalence(F&& test)
     {
@@ -97,6 +104,8 @@ private:
 
     void minimizeTrace(machine_trace& trace);
     void reproduceTrace(cc::span<int const> serialized_trace);
+
+    machine_trace deserializeTrace(cc::span<int const> serialized_trace);
 
     /// tries to replace a trace
     /// returns false if trace is invalid (e.g. violates a precondition)
@@ -415,6 +424,8 @@ private:
     cc::vector<cc::unique_function<void()>> mPreCallbacks;
     cc::vector<cc::unique_function<void()>> mPostCallbacks;
     cc::vector<equivalence> mEquivalences;
+
+    cc::vector<cc::string> mFixedReproductions;
 
     machine_trace* mCurrentTrace = nullptr;
 

--- a/src/nexus/tests/MonteCarloTest.hh
+++ b/src/nexus/tests/MonteCarloTest.hh
@@ -91,7 +91,7 @@ public:
 
     // impls
 private:
-    void tryExecuteMachineNormally(machine_trace& trace);
+    void tryExecuteMachineNormally(machine_trace& trace, size_t seed);
 
     void minimizeTrace(machine_trace& trace);
     void reproduceTrace(cc::span<int const> serialized_trace);

--- a/src/nexus/tests/Test.cc
+++ b/src/nexus/tests/Test.cc
@@ -1,1 +1,17 @@
 #include "Test.hh"
+
+#include <clean-core/format.hh>
+
+#include "MonteCarloTest.hh"
+
+cc::string nx::Test::makeCurrentReproductionCommand() const
+{
+    if (mMCT)
+    {
+        auto tr = mMCT->mCurrentTrace;
+        CC_ASSERT(tr != nullptr && "no current trace (must be called during execution)");
+        return cc::format("reproduce(\"%s\")", tr->serialize_to_string(*mMCT));
+    }
+
+    CC_UNREACHABLE("non-MCT not implemented currently");
+}

--- a/src/nexus/tests/Test.hh
+++ b/src/nexus/tests/Test.hh
@@ -51,6 +51,7 @@ public:
     void setDebug() { mIsDebug = true; }
     void setVerbose() { mIsVerbose = true; }
     void setReproduce(reproduce r) { mReproduction = r; }
+    void setMonteCarloTest(MonteCarloTest* mct) { mMCT = mct; }
     void addAfterPattern(cc::string pattern) { mAfterPatterns.push_back(cc::move(pattern)); }
     void addBeforePattern(cc::string pattern) { mBeforePatterns.push_back(cc::move(pattern)); }
 
@@ -61,6 +62,8 @@ public:
     }
 
     void setDidFail(bool didFail) { mDidFail = didFail; }
+
+    cc::string makeCurrentReproductionCommand() const;
 
     // ctor
 public:
@@ -98,6 +101,8 @@ private:
 
     int mArgC = 0;
     char const* const* mArgV = nullptr;
+
+    MonteCarloTest* mMCT = nullptr;
 
     reproduce mReproduction = reproduce::none();
 

--- a/src/nexus/tests/Test.hh
+++ b/src/nexus/tests/Test.hh
@@ -110,6 +110,7 @@ private:
     cc::vector<cc::string> mBeforePatterns;
 
     friend class Nexus;
+    friend class MonteCarloTest;
 };
 
 namespace detail


### PR DESCRIPTION
Contains all of pt/develop, plus:
- Fix `MonteCarloTest` for DLL linked nexus
- Rename Cmake option to force macro prefixes to be in line with other (arcana_ macro-provided) NX_ options
- Fix compilation when used with rich-log where macro prefixes are forced